### PR TITLE
Spam check based on message length and checksums

### DIFF
--- a/S2Wrapper.py
+++ b/S2Wrapper.py
@@ -11,6 +11,7 @@ from collections import deque
 import ConfigParser
 import stty
 from threading import Timer
+import string
 
 
 
@@ -62,7 +63,8 @@ class Savage2Thread(threading.Thread):
 		args = [config['exec']]
 		if config['args']:
 			args += [config['args']]
-		env = [config['env']]
+		#env = [config['env']]
+		env = string.splitfields(config['env'], '=')
 
 		termold = stty.getSize()
 		termcfg = (int(config['term_x']), int(config['term_y']))
@@ -73,6 +75,8 @@ class Savage2Thread(threading.Thread):
 
 		print("starting: %s" % (args))
 		try:
+			if len(env) == 2:
+				os.environ[env[0].strip()] = env[1].strip()
 			self.process = subprocess.Popen(args, stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
 			#self.process = subprocess.Popen(args, env=env, stdin=subprocess.PIPE, stdout=subprocess.PIPE, universal_newlines=True)
 			print("[%s] has started successfully" % (self.process.pid))


### PR DESCRIPTION
Replaced typing rate-based spam-check with one that's based on message length and checksum. The typing-rate check is unreliable due to lag and unreliable message length provided by the wrapper.
